### PR TITLE
refactor: Convert from tofu-plan to tofu-apply action

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,37 @@
-# GitHub Tofu Plan Action
+# GitHub Tofu Apply Action
 
-This GitHub Action runs `tofu plan` with all supported options, automating OpenTofu planning in your CI/CD workflows.
+This GitHub Action runs `tofu apply` with all supported options, automating OpenTofu application in your CI/CD workflows.
 
 ## Quick Start
 
-The most basic usage - create a plan for OpenTofu in your current directory:
+The most basic usage - apply OpenTofu configuration with auto-approval:
 
 ```yaml
 steps:
   - uses: actions/checkout@v4
-  - uses: dnogu/tofu-plan@v1
+  - uses: dnogu/tofu-apply@v1
+    with:
+      auto-approve: true
 ```
 
 ## Usage
 
 ```yaml
-name: Plan OpenTofu
+name: Apply OpenTofu
 on:
   push:
     branches: [ main ]
 jobs:
-  tofu-plan:
+  tofu-apply:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Run tofu plan
-        uses: dnogu/tofu-plan@v1
+      - name: Run tofu apply
+        uses: dnogu/tofu-apply@v1
         with:
           working-directory: ./infra
+          auto-approve: true
           destroy: false
           refresh-only: false
           refresh: true
@@ -39,10 +42,9 @@ jobs:
           exclude-file: ""
           var: "foo=bar,bar=baz"
           var-file: "variables.tfvars"
-          out: "tfplan"
           compact-warnings: false
-          detailed-exitcode: false
-          generate-config-out: ""
+          consolidate-warnings: false
+          consolidate-errors: false
           input: false
           json: false
           lock: true
@@ -51,7 +53,10 @@ jobs:
           concise: false
           parallelism: 10
           state: ""
+          state-out: ""
+          backup: ""
           show-sensitive: false
+          deprecation: "module:all"
 
 ```
 
@@ -59,44 +64,48 @@ jobs:
 
 | Name                | Description                                                                 | Default      |
 |---------------------|-----------------------------------------------------------------------------|-------------|
-| working-directory   | The directory in which to run tofu plan.                                    | `.`         |
-| chdir               | Switch working directory before executing tofu plan (--chdir).               | `''`        |
-| destroy             | Create a destroy plan (--destroy).                                          | `false`     |
-| refresh-only        | Create a refresh-only plan (--refresh-only).                                | `false`     |
-| refresh             | Skip the default behavior of syncing state before planning (--refresh=false). | `true`      |
-| replace             | Force replacement of particular resource instances (--replace=ADDRESS).      | `''`        |
-| target              | Limit planning to only the given resource instances (--target=ADDRESS).      | `''`        |
-| target-file         | Limit planning to resource instances listed in file (--target-file=FILE).    | `''`        |
-| exclude             | Exclude specific resource instances from planning (--exclude=ADDRESS).       | `''`        |
-| exclude-file        | Exclude resource instances listed in file (--exclude-file=FILE).            | `''`        |
-| var                 | Set input variable(s) (--var NAME=VALUE, comma separated).                  | `''`        |
-| var-file            | Set input variables from file(s) (--var-file=FILENAME, comma separated).     | `''`        |
-| out                 | Write the plan to the given filename (--out=FILENAME).                      | `''`        |
+| working-directory   | The directory in which to run tofu apply.                                    | `.`         |
+| chdir               | Switch working directory before executing tofu apply (--chdir).               | `''`        |
+| plan-file           | Path to a saved plan file to apply. If provided, skips planning phase.      | `''`        |
+| auto-approve        | Skip interactive approval of plan before applying (--auto-approve).         | `false`     |
+| destroy             | Create a destroy plan (--destroy). Only available when not using a saved plan file. | `false`     |
+| refresh-only        | Create a refresh-only plan (--refresh-only). Only available when not using a saved plan file. | `false`     |
+| refresh             | Skip the default behavior of syncing state before applying (--refresh=false). Only available when not using a saved plan file. | `true`      |
+| replace             | Force replacement of particular resource instances (--replace=ADDRESS). Only available when not using a saved plan file. | `''`        |
+| target              | Limit applying to only the given resource instances (--target=ADDRESS). Only available when not using a saved plan file. | `''`        |
+| target-file         | Limit applying to resource instances listed in file (--target-file=FILE). Only available when not using a saved plan file. | `''`        |
+| exclude             | Exclude specific resource instances from applying (--exclude=ADDRESS). Only available when not using a saved plan file. | `''`        |
+| exclude-file        | Exclude resource instances listed in file (--exclude-file=FILE). Only available when not using a saved plan file. | `''`        |
+| var                 | Set input variable(s) (--var NAME=VALUE, comma separated). Only available when not using a saved plan file. | `''`        |
+| var-file            | Set input variables from file(s) (--var-file=FILENAME, comma separated). Only available when not using a saved plan file. | `''`        |
 | compact-warnings    | Show warning messages in compact form (--compact-warnings).                 | `false`     |
-| detailed-exitcode   | Return detailed exit code (--detailed-exitcode).                            | `false`     |
-| generate-config-out | Generate configuration for import blocks (--generate-config-out=PATH).      | `''`        |
+| consolidate-warnings| Consolidate similar warning messages (--consolidate-warnings).              | `false`     |
+| consolidate-errors  | Consolidate similar error messages (--consolidate-errors).                  | `false`     |
 | input               | Ask for input if necessary (--input=true|false).                            | `false`     |
-| json                | Produce output in JSON format (--json).                                     | `false`     |
+| json                | Produce output in JSON format (--json). Requires --auto-approve or saved plan file. | `false`     |
 | lock                | Enable or disable state locking (--lock=true|false).                        | `true`      |
 | lock-timeout        | Override the time to wait for a state lock (--lock-timeout=DURATION).       | `0s`        |
 | no-color            | Disable color codes in output (--no-color).                                 | `false`     |
 | concise             | Disable progress-related messages (--concise).                              | `false`     |
 | parallelism         | Limit the number of concurrent operations (--parallelism=n).                | `10`        |
 | state               | Legacy option for local backend only (--state=STATEFILE).                   | `''`        |
+| state-out           | Legacy option for local backend only (--state-out=STATEFILE).               | `''`        |
+| backup              | Legacy option for local backend only (--backup=BACKUPFILE).                 | `''`        |
 | show-sensitive      | Display sensitive values in output (--show-sensitive).                      | `false`     |
-| display-plan        | Display the plan output in the GitHub Actions log (true/false).             | `true`      |
+| deprecation         | Specify what type of warnings are shown (--deprecation=module:all|module:local|module:none). | `module:all` |
+| display-output      | Display the apply output in the GitHub Actions log (true/false).            | `true`      |
 
 ## Outputs
 
 | Name         | Description                      |
 |--------------|----------------------------------|
-| plan-output  | The output from tofu plan.       |
-| exitcode     | The exit code from tofu plan.    |
+| apply-output | The output from tofu apply.      |
+| exitcode     | The exit code from tofu apply.   |
 
 
 ## Examples
 
-### Basic Tofu Plan
+### Basic Tofu Apply with Auto-Approval
 ```yaml
 steps:
   - name: Checkout code
@@ -107,13 +116,14 @@ steps:
     with:
       tofu_version: '1.8.0'
   
-  - name: Run Basic Tofu Plan
-    uses: dnogu/tofu-plan@v1
+  - name: Run Basic Tofu Apply
+    uses: dnogu/tofu-apply@v1
     with:
       working-directory: ./infra
+      auto-approve: true
 ```
 
-### Tofu Plan with Variables
+### Tofu Apply with Variables
 ```yaml
 steps:
   - name: Checkout code
@@ -124,15 +134,16 @@ steps:
     with:
       tofu_version: '1.8.0'
   
-  - name: Run tofu plan with variables
-    uses: dnogu/tofu-plan@v1
+  - name: Run tofu apply with variables
+    uses: dnogu/tofu-apply@v1
     with:
       working-directory: ./infra
+      auto-approve: true
       var: "environment=production,region=us-east-1"
       var-file: "prod.tfvars"
 ```
 
-### Tofu Plan with Output File
+### Apply Saved Plan File
 ```yaml
 steps:
   - name: Checkout code
@@ -143,20 +154,20 @@ steps:
     with:
       tofu_version: '1.8.0'
   
-  - name: Create Plan
-    uses: dnogu/tofu-plan@v1
-    with:
-      working-directory: ./infra
-      out: "tfplan"
-  
-  - name: Upload Plan
-    uses: actions/upload-artifact@v4
+  - name: Download Plan
+    uses: actions/download-artifact@v4
     with:
       name: terraform-plan
-      path: ./infra/tfplan
+      path: ./infra
+  
+  - name: Apply Plan
+    uses: dnogu/tofu-apply@v1
+    with:
+      working-directory: ./infra
+      plan-file: "tfplan"
 ```
 
-### Quiet Plan (No Output Display)
+### Destroy Infrastructure
 ```yaml
 steps:
   - name: Checkout code
@@ -167,13 +178,108 @@ steps:
     with:
       tofu_version: '1.8.0'
   
-  - name: Run Quiet Plan
-    uses: dnogu/tofu-plan@v1
+  - name: Destroy Infrastructure
+    uses: dnogu/tofu-apply@v1
     with:
       working-directory: ./infra
-      display-plan: false
-      out: "plan-output"
+      destroy: true
+      auto-approve: true
 ```
+
+### Quiet Apply (No Output Display)
+```yaml
+steps:
+  - name: Checkout code
+    uses: actions/checkout@v4
+  
+  - name: Setup OpenTofu
+    uses: opentofu/setup-opentofu@v1
+    with:
+      tofu_version: '1.8.0'
+  
+  - name: Run Quiet Apply
+    uses: dnogu/tofu-apply@v1
+    with:
+      working-directory: ./infra
+      auto-approve: true
+      display-output: false
+```
+
+### Apply with Target Resources
+```yaml
+steps:
+  - name: Checkout code
+    uses: actions/checkout@v4
+  
+  - name: Setup OpenTofu
+    uses: opentofu/setup-opentofu@v1
+    with:
+      tofu_version: '1.8.0'
+  
+  - name: Apply Specific Resources
+    uses: dnogu/tofu-apply@v1
+    with:
+      working-directory: ./infra
+      auto-approve: true
+      target: "aws_instance.web,aws_security_group.web"
+```
+
+## Two-Step Workflow with Plan and Apply
+
+For production environments, you might want to use a two-step workflow:
+
+```yaml
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup OpenTofu
+        uses: opentofu/setup-opentofu@v1
+        with:
+          tofu_version: '1.8.0'
+      - name: Create Plan
+        uses: dnogu/tofu-plan@v1
+        with:
+          working-directory: ./infra
+          out: "tfplan"
+      - name: Upload Plan
+        uses: actions/upload-artifact@v4
+        with:
+          name: terraform-plan
+          path: ./infra/tfplan
+
+  apply:
+    needs: plan
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup OpenTofu
+        uses: opentofu/setup-opentofu@v1
+        with:
+          tofu_version: '1.8.0'
+      - name: Download Plan
+        uses: actions/download-artifact@v4
+        with:
+          name: terraform-plan
+          path: ./infra
+      - name: Apply Plan
+        uses: dnogu/tofu-apply@v1
+        with:
+          working-directory: ./infra
+          plan-file: "tfplan"
+```
+
+## Features
+
+- **Automatic Plan Mode**: When no plan file is provided, automatically creates and applies a plan
+- **Saved Plan Mode**: When a plan file is provided, applies the pre-created plan without prompting
+- **Auto-approval**: Skip interactive confirmation with `--auto-approve`
+- **Comprehensive Options**: Supports all tofu apply command-line options
+- **Error Consolidation**: Options to consolidate similar warnings and errors
+- **Flexible Output**: Control output display and formatting
+- **Legacy Backend Support**: Includes support for legacy local backend options
 
 ## Author
 
@@ -185,4 +291,4 @@ MIT
 
 ---
 
-*This action has been updated to use `tofu plan` instead of `tofu init`. For OpenTofu initialization, consider using a separate init action first.*
+*This action applies OpenTofu configurations. For planning only, use the `tofu-plan` action.*

--- a/__tests__/integration.test.js
+++ b/__tests__/integration.test.js
@@ -1,40 +1,49 @@
-const { buildTofuPlanCommand } = require('../index');
+const { buildTofuApplyCommand } = require('../index');
 
-describe('OpenTofu Plan Integration Tests', () => {
+describe('OpenTofu Apply Integration Tests', () => {
   describe('Basic scenarios', () => {
-    test('should generate command for basic local development', () => {
+    test('should generate command for basic local development apply', () => {
       const inputs = {
-        var: 'environment=dev'
+        var: 'environment=dev',
+        autoApprove: 'true'
       };
-      expect(buildTofuPlanCommand(inputs)).toBe('tofu plan --var=environment=dev');
+      expect(buildTofuApplyCommand(inputs)).toBe('tofu apply --auto-approve --var=environment=dev');
     });
 
-    test('should generate command for production planning', () => {
+    test('should generate command for production apply with saved plan', () => {
+      const inputs = {
+        planFile: 'prod-plan'
+      };
+      expect(buildTofuApplyCommand(inputs)).toBe('tofu apply prod-plan');
+    });
+
+    test('should generate command for production apply in automatic plan mode', () => {
       const inputs = {
         varFile: 'prod.tfvars',
         var: 'environment=production',
-        out: 'prod-plan'
+        autoApprove: 'true'
       };
-      expect(buildTofuPlanCommand(inputs)).toBe('tofu plan --var=environment=production --var-file=prod.tfvars --out=prod-plan');
+      expect(buildTofuApplyCommand(inputs)).toBe('tofu apply --auto-approve --var=environment=production --var-file=prod.tfvars');
     });
   });
 
-  describe('Planning mode scenarios', () => {
-    test('should generate command for destroy planning', () => {
+  describe('Apply mode scenarios', () => {
+    test('should generate command for destroy apply', () => {
       const inputs = {
         destroy: 'true',
         var: 'environment=staging',
-        out: 'destroy-plan'
+        autoApprove: 'true'
       };
-      expect(buildTofuPlanCommand(inputs)).toBe('tofu plan --destroy --var=environment=staging --out=destroy-plan');
+      expect(buildTofuApplyCommand(inputs)).toBe('tofu apply --auto-approve --destroy --var=environment=staging');
     });
 
-    test('should generate command for refresh-only planning', () => {
+    test('should generate command for refresh-only apply', () => {
       const inputs = {
         refreshOnly: 'true',
-        noColor: 'true'
+        noColor: 'true',
+        autoApprove: 'true'
       };
-      expect(buildTofuPlanCommand(inputs)).toBe('tofu plan --refresh-only --no-color');
+      expect(buildTofuApplyCommand(inputs)).toBe('tofu apply --auto-approve --no-color --refresh-only');
     });
   });
 
@@ -42,64 +51,76 @@ describe('OpenTofu Plan Integration Tests', () => {
     test('should generate command for resource targeting', () => {
       const inputs = {
         target: 'aws_instance.web,aws_security_group.web',
-        var: 'instance_type=t3.medium'
+        var: 'instance_type=t3.medium',
+        autoApprove: 'true'
       };
-      expect(buildTofuPlanCommand(inputs)).toBe('tofu plan --target=aws_instance.web --target=aws_security_group.web --var=instance_type=t3.medium');
+      expect(buildTofuApplyCommand(inputs)).toBe('tofu apply --auto-approve --target=aws_instance.web --target=aws_security_group.web --var=instance_type=t3.medium');
     });
 
     test('should generate command for resource replacement', () => {
       const inputs = {
         replace: 'aws_instance.database',
-        out: 'replacement-plan'
+        autoApprove: 'true'
       };
-      expect(buildTofuPlanCommand(inputs)).toBe('tofu plan --replace=aws_instance.database --out=replacement-plan');
+      expect(buildTofuApplyCommand(inputs)).toBe('tofu apply --auto-approve --replace=aws_instance.database');
     });
   });
 
-  describe('Variable and output scenarios', () => {
-    test('should generate command for planning with multiple variables', () => {
+  describe('Variable and apply scenarios', () => {
+    test('should generate command for apply with multiple variables', () => {
       const inputs = {
         var: 'random_length=16,random_prefix=test',
-        varFile: 'random.tfvars'
+        varFile: 'random.tfvars',
+        autoApprove: 'true'
       };
-      expect(buildTofuPlanCommand(inputs)).toBe('tofu plan --var=random_length=16 --var=random_prefix=test --var-file=random.tfvars');
+      expect(buildTofuApplyCommand(inputs)).toBe('tofu apply --auto-approve --var=random_length=16 --var=random_prefix=test --var-file=random.tfvars');
     });
 
-    test('should generate command for planning with multiple var files', () => {
+    test('should generate command for apply with multiple var files', () => {
       const inputs = {
         varFile: 'common.tfvars,random.tfvars,secrets.tfvars',
         var: 'seed_value=12345',
-        out: 'multi-var-plan'
+        autoApprove: 'true'
       };
-      expect(buildTofuPlanCommand(inputs)).toBe('tofu plan --var=seed_value=12345 --var-file=common.tfvars --var-file=random.tfvars --var-file=secrets.tfvars --out=multi-var-plan');
+      expect(buildTofuApplyCommand(inputs)).toBe('tofu apply --auto-approve --var=seed_value=12345 --var-file=common.tfvars --var-file=random.tfvars --var-file=secrets.tfvars');
     });
 
-    test('should generate command for planning in subdirectory with JSON output', () => {
+    test('should generate command for apply in subdirectory with JSON output', () => {
       const inputs = {
         chdir: './modules/random',
         json: 'true',
         noColor: 'true',
-        var: 'length=32'
+        var: 'length=32',
+        autoApprove: 'true'
       };
-      expect(buildTofuPlanCommand(inputs)).toBe('tofu -chdir=./modules/random plan --var=length=32 --json --no-color');
+      expect(buildTofuApplyCommand(inputs)).toBe('tofu -chdir=./modules/random apply --auto-approve --json --no-color --var=length=32');
     });
   });
 
-  describe('Advanced planning scenarios', () => {
-    test('should generate command for planning with file-based targeting', () => {
+  describe('Advanced apply scenarios', () => {
+    test('should generate command for apply with file-based targeting', () => {
       const inputs = {
         targetFile: 'targets.txt',
-        var: 'environment=staging'
+        var: 'environment=staging',
+        autoApprove: 'true'
       };
-      expect(buildTofuPlanCommand(inputs)).toBe('tofu plan --target-file=targets.txt --var=environment=staging');
+      expect(buildTofuApplyCommand(inputs)).toBe('tofu apply --auto-approve --target-file=targets.txt --var=environment=staging');
     });
 
     test('should generate command with exclusions', () => {
       const inputs = {
         exclude: 'aws_instance.test,module.test_module',
-        out: 'filtered-plan'
+        autoApprove: 'true'
       };
-      expect(buildTofuPlanCommand(inputs)).toBe('tofu plan --exclude=aws_instance.test --exclude=module.test_module --out=filtered-plan');
+      expect(buildTofuApplyCommand(inputs)).toBe('tofu apply --auto-approve --exclude=aws_instance.test --exclude=module.test_module');
+    });
+
+    test('should generate command for apply with saved plan file', () => {
+      const inputs = {
+        planFile: 'saved-plan',
+        noColor: 'true'
+      };
+      expect(buildTofuApplyCommand(inputs)).toBe('tofu apply saved-plan --no-color');
     });
   });
 
@@ -108,23 +129,33 @@ describe('OpenTofu Plan Integration Tests', () => {
       const inputs = {
         input: 'false',
         noColor: 'true',
-        detailedExitcode: 'true',
         varFile: 'ci.tfvars',
-        out: 'ci-plan'
+        autoApprove: 'true'
       };
-      expect(buildTofuPlanCommand(inputs)).toBe('tofu plan --var-file=ci.tfvars --detailed-exitcode --input=false --no-color --out=ci-plan');
+      expect(buildTofuApplyCommand(inputs)).toBe('tofu apply --auto-approve --input=false --no-color --var-file=ci.tfvars');
     });
 
-    test('should generate command for automated deployment planning', () => {
+    test('should generate command for automated deployment apply', () => {
       const inputs = {
         input: 'false',
         lock: 'false',
         noColor: 'true',
         json: 'true',
         var: 'deployment_id=${Date.now()}',
-        parallelism: '1'
+        parallelism: '1',
+        autoApprove: 'true'
       };
-      expect(buildTofuPlanCommand(inputs)).toBe('tofu plan --var=deployment_id=${Date.now()} --input=false --json --lock=false --no-color --parallelism=1');
+      expect(buildTofuApplyCommand(inputs)).toBe('tofu apply --auto-approve --input=false --json --lock=false --no-color --parallelism=1 --var=deployment_id=${Date.now()}');
+    });
+
+    test('should generate command for apply with saved plan in CI', () => {
+      const inputs = {
+        planFile: 'ci-plan',
+        input: 'false',
+        noColor: 'true',
+        json: 'true'
+      };
+      expect(buildTofuApplyCommand(inputs)).toBe('tofu apply ci-plan --input=false --json --no-color');
     });
   });
 
@@ -136,7 +167,7 @@ describe('OpenTofu Plan Integration Tests', () => {
         target: null,
         chdir: ''
       };
-      expect(buildTofuPlanCommand(inputs)).toBe('tofu plan');
+      expect(buildTofuApplyCommand(inputs)).toBe('tofu apply');
     });
 
     test('should handle mixed valid and invalid inputs', () => {
@@ -145,9 +176,24 @@ describe('OpenTofu Plan Integration Tests', () => {
         var: 'valid=true',
         varFile: '',
         target: 'aws_instance.test',
-        invalidOption: 'should-be-ignored'
+        invalidOption: 'should-be-ignored',
+        autoApprove: 'true'
       };
-      expect(buildTofuPlanCommand(inputs)).toBe('tofu plan --destroy --target=aws_instance.test --var=valid=true');
+      expect(buildTofuApplyCommand(inputs)).toBe('tofu apply --auto-approve --destroy --target=aws_instance.test --var=valid=true');
+    });
+
+    test('should ignore planning options when using saved plan file', () => {
+      const inputs = {
+        planFile: 'saved-plan',
+        // These should be ignored
+        destroy: 'true',
+        var: 'ignored=true',
+        target: 'aws_instance.ignored',
+        // These should be included
+        autoApprove: 'true',
+        noColor: 'true'
+      };
+      expect(buildTofuApplyCommand(inputs)).toBe('tofu apply saved-plan --auto-approve --no-color');
     });
   });
 
@@ -157,29 +203,27 @@ describe('OpenTofu Plan Integration Tests', () => {
         chdir: './environments/staging',
         varFile: 'common.tfvars,staging.tfvars',
         var: 'environment=staging,region=us-east-1,instance_count=2',
-        detailedExitcode: 'true',
         lockTimeout: '300s',
-        out: 'staging-plan'
+        autoApprove: 'true'
       };
       
-      const expected = 'tofu -chdir=./environments/staging plan --var=environment=staging --var=region=us-east-1 --var=instance_count=2 --var-file=common.tfvars --var-file=staging.tfvars --detailed-exitcode --lock-timeout=300s --out=staging-plan';
-      expect(buildTofuPlanCommand(inputs)).toBe(expected);
+      const expected = 'tofu -chdir=./environments/staging apply --auto-approve --lock-timeout=300s --var=environment=staging --var=region=us-east-1 --var=instance_count=2 --var-file=common.tfvars --var-file=staging.tfvars';
+      expect(buildTofuApplyCommand(inputs)).toBe(expected);
     });
 
-    test('should generate command for comprehensive planning scenario', () => {
+    test('should generate command for comprehensive apply scenario', () => {
       const inputs = {
         target: 'aws_instance.web,aws_security_group.web',
         replace: 'aws_instance.database',
         var: 'environment=production,backup_enabled=true',
         varFile: 'prod.tfvars',
-        out: 'comprehensive-plan',
-        detailedExitcode: 'true',
         input: 'false',
-        noColor: 'true'
+        noColor: 'true',
+        autoApprove: 'true'
       };
       
-      const expected = 'tofu plan --replace=aws_instance.database --target=aws_instance.web --target=aws_security_group.web --var=environment=production --var=backup_enabled=true --var-file=prod.tfvars --detailed-exitcode --input=false --no-color --out=comprehensive-plan';
-      expect(buildTofuPlanCommand(inputs)).toBe(expected);
+      const expected = 'tofu apply --auto-approve --input=false --no-color --replace=aws_instance.database --target=aws_instance.web --target=aws_security_group.web --var=environment=production --var=backup_enabled=true --var-file=prod.tfvars';
+      expect(buildTofuApplyCommand(inputs)).toBe(expected);
     });
   });
 });

--- a/action.yml
+++ b/action.yml
@@ -1,80 +1,84 @@
-name: 'Tofu Plan'
-description: 'A GitHub Action to run tofu plan with all supported options.'
+name: 'Tofu Apply'
+description: 'A GitHub Action to run tofu apply with all supported options.'
 author: 'dnogu'
 runs:
   using: 'node20'
   main: 'dist/index.js'
 inputs:
   working-directory:
-    description: 'The directory in which to run tofu plan.'
+    description: 'The directory in which to run tofu apply.'
     required: false
     default: '.'
   chdir:
-    description: 'Switch working directory before executing tofu plan (--chdir).'
+    description: 'Switch working directory before executing tofu apply (--chdir).'
     required: false
     default: ''
+  plan-file:
+    description: 'Path to a saved plan file to apply. If provided, skips planning phase.'
+    required: false
+    default: ''
+  auto-approve:
+    description: 'Skip interactive approval of plan before applying (--auto-approve).'
+    required: false
+    default: 'false'
   destroy:
-    description: 'Create a destroy plan (--destroy).'
+    description: 'Create a destroy plan (--destroy). Only available when not using a saved plan file.'
     required: false
     default: 'false'
   refresh-only:
-    description: 'Create a refresh-only plan (--refresh-only).'
+    description: 'Create a refresh-only plan (--refresh-only). Only available when not using a saved plan file.'
     required: false
     default: 'false'
   refresh:
-    description: 'Skip the default behavior of syncing state before planning (--refresh=false).'
+    description: 'Skip the default behavior of syncing state before applying (--refresh=false). Only available when not using a saved plan file.'
     required: false
     default: 'true'
   replace:
-    description: 'Force replacement of particular resource instances (--replace=ADDRESS, comma separated).'
+    description: 'Force replacement of particular resource instances (--replace=ADDRESS, comma separated). Only available when not using a saved plan file.'
     required: false
     default: ''
   target:
-    description: 'Limit planning to only the given resource instances (--target=ADDRESS, comma separated).'
+    description: 'Limit applying to only the given resource instances (--target=ADDRESS, comma separated). Only available when not using a saved plan file.'
     required: false
     default: ''
   target-file:
-    description: 'Limit planning to resource instances listed in file (--target-file=FILE).'
+    description: 'Limit applying to resource instances listed in file (--target-file=FILE). Only available when not using a saved plan file.'
     required: false
     default: ''
   exclude:
-    description: 'Exclude specific resource instances from planning (--exclude=ADDRESS, comma separated).'
+    description: 'Exclude specific resource instances from applying (--exclude=ADDRESS, comma separated). Only available when not using a saved plan file.'
     required: false
     default: ''
   exclude-file:
-    description: 'Exclude resource instances listed in file (--exclude-file=FILE).'
+    description: 'Exclude resource instances listed in file (--exclude-file=FILE). Only available when not using a saved plan file.'
     required: false
     default: ''
   var:
-    description: 'Set input variable(s) (--var NAME=VALUE, comma separated).'
+    description: 'Set input variable(s) (--var NAME=VALUE, comma separated). Only available when not using a saved plan file.'
     required: false
     default: ''
   var-file:
-    description: 'Set input variables from file(s) (--var-file=FILENAME, comma separated).'
-    required: false
-    default: ''
-  out:
-    description: 'Write the plan to the given filename (--out=FILENAME).'
+    description: 'Set input variables from file(s) (--var-file=FILENAME, comma separated). Only available when not using a saved plan file.'
     required: false
     default: ''
   compact-warnings:
     description: 'Show warning messages in compact form (--compact-warnings).'
     required: false
     default: 'false'
-  detailed-exitcode:
-    description: 'Return detailed exit code (--detailed-exitcode).'
+  consolidate-warnings:
+    description: 'Consolidate similar warning messages (--consolidate-warnings).'
     required: false
     default: 'false'
-  generate-config-out:
-    description: 'Generate configuration for import blocks (--generate-config-out=PATH).'
+  consolidate-errors:
+    description: 'Consolidate similar error messages (--consolidate-errors).'
     required: false
-    default: ''
+    default: 'false'
   input:
     description: 'Ask for input if necessary (--input=true|false).'
     required: false
     default: 'false'
   json:
-    description: 'Produce output in JSON format (--json).'
+    description: 'Produce output in JSON format (--json). Requires --auto-approve or saved plan file.'
     required: false
     default: 'false'
   lock:
@@ -101,19 +105,31 @@ inputs:
     description: 'Legacy option for local backend only (--state=STATEFILE).'
     required: false
     default: ''
+  state-out:
+    description: 'Legacy option for local backend only (--state-out=STATEFILE).'
+    required: false
+    default: ''
+  backup:
+    description: 'Legacy option for local backend only (--backup=BACKUPFILE).'
+    required: false
+    default: ''
   show-sensitive:
     description: 'Display sensitive values in output (--show-sensitive).'
     required: false
     default: 'false'
-  display-plan:
-    description: 'Display the plan output in the GitHub Actions log (true/false).'
+  deprecation:
+    description: 'Specify what type of warnings are shown (--deprecation=module:all|module:local|module:none).'
+    required: false
+    default: 'module:all'
+  display-output:
+    description: 'Display the apply output in the GitHub Actions log (true/false).'
     required: false
     default: 'true'
 outputs:
-  plan-output:
-    description: 'The output from tofu plan.'
+  apply-output:
+    description: 'The output from tofu apply.'
   exitcode:
-    description: 'The exit code from tofu plan.'
+    description: 'The exit code from tofu apply.'
 branding:
-  icon: 'eye'
-  color: 'blue'
+  icon: 'check-circle'
+  color: 'green'

--- a/dist/index.js
+++ b/dist/index.js
@@ -32,42 +32,69 @@ function getRepeatableFlag(name, value) {
   return value.split(',').map(v => `--${name}=${v.trim()}`);
 }
 
-function buildTofuPlanCommand(inputs) {
-  let cmdParts = ['tofu', 'plan'];
+function buildTofuApplyCommand(inputs) {
+  let cmdParts = ['tofu', 'apply'];
 
   // Global option
   if (inputs.chdir) {
-    cmdParts = ['tofu', `-chdir=${inputs.chdir}`, 'plan'];
+    cmdParts = ['tofu', `-chdir=${inputs.chdir}`, 'apply'];
   }
 
-  // Planning modes (mutually exclusive)
-  if (inputs.destroy === 'true') cmdParts.push('--destroy');
-  if (inputs.refreshOnly === 'true') cmdParts.push('--refresh-only');
+  // If plan file is provided, use saved plan mode
+  if (inputs.planFile) {
+    cmdParts.push(inputs.planFile);
+    // In saved plan mode, only certain options are allowed
+    if (inputs.autoApprove === 'true') cmdParts.push('--auto-approve');
+    if (inputs.compactWarnings === 'true') cmdParts.push('--compact-warnings');
+    if (inputs.consolidateWarnings === 'true') cmdParts.push('--consolidate-warnings');
+    if (inputs.consolidateErrors === 'true') cmdParts.push('--consolidate-errors');
+    if (inputs.input === 'false') cmdParts.push('--input=false');
+    if (inputs.json === 'true') cmdParts.push('--json');
+    if (inputs.lock === 'false') cmdParts.push('--lock=false');
+    if (inputs.lockTimeout && inputs.lockTimeout !== '0s') cmdParts.push(getFlag('lock-timeout', inputs.lockTimeout, 'string'));
+    if (inputs.noColor === 'true') cmdParts.push('--no-color');
+    if (inputs.concise === 'true') cmdParts.push('--concise');
+    if (inputs.parallelism && inputs.parallelism !== '10') cmdParts.push(getFlag('parallelism', inputs.parallelism, 'string'));
+    if (inputs.state) cmdParts.push(getFlag('state', inputs.state, 'string'));
+    if (inputs.stateOut) cmdParts.push(getFlag('state-out', inputs.stateOut, 'string'));
+    if (inputs.backup) cmdParts.push(getFlag('backup', inputs.backup, 'string'));
+    if (inputs.showSensitive === 'true') cmdParts.push('--show-sensitive');
+    if (inputs.deprecation && inputs.deprecation !== 'module:all') cmdParts.push(getFlag('deprecation', inputs.deprecation, 'string'));
+  } else {
+    // Automatic plan mode - planning options are available
+    
+    // Apply-specific options
+    if (inputs.autoApprove === 'true') cmdParts.push('--auto-approve');
+    if (inputs.compactWarnings === 'true') cmdParts.push('--compact-warnings');
+    if (inputs.consolidateWarnings === 'true') cmdParts.push('--consolidate-warnings');
+    if (inputs.consolidateErrors === 'true') cmdParts.push('--consolidate-errors');
+    if (inputs.input === 'false') cmdParts.push('--input=false');
+    if (inputs.json === 'true') cmdParts.push('--json');
+    if (inputs.lock === 'false') cmdParts.push('--lock=false');
+    if (inputs.lockTimeout && inputs.lockTimeout !== '0s') cmdParts.push(getFlag('lock-timeout', inputs.lockTimeout, 'string'));
+    if (inputs.noColor === 'true') cmdParts.push('--no-color');
+    if (inputs.concise === 'true') cmdParts.push('--concise');
+    if (inputs.parallelism && inputs.parallelism !== '10') cmdParts.push(getFlag('parallelism', inputs.parallelism, 'string'));
+    if (inputs.state) cmdParts.push(getFlag('state', inputs.state, 'string'));
+    if (inputs.stateOut) cmdParts.push(getFlag('state-out', inputs.stateOut, 'string'));
+    if (inputs.backup) cmdParts.push(getFlag('backup', inputs.backup, 'string'));
+    if (inputs.showSensitive === 'true') cmdParts.push('--show-sensitive');
+    if (inputs.deprecation && inputs.deprecation !== 'module:all') cmdParts.push(getFlag('deprecation', inputs.deprecation, 'string'));
 
-  // Planning options
-  if (inputs.refresh === 'false') cmdParts.push('--refresh=false');
-  cmdParts = cmdParts.concat(getRepeatableFlag('replace', inputs.replace));
-  cmdParts = cmdParts.concat(getRepeatableFlag('target', inputs.target));
-  if (inputs.targetFile) cmdParts.push(getFlag('target-file', inputs.targetFile, 'string'));
-  cmdParts = cmdParts.concat(getRepeatableFlag('exclude', inputs.exclude));
-  if (inputs.excludeFile) cmdParts.push(getFlag('exclude-file', inputs.excludeFile, 'string'));
-  cmdParts = cmdParts.concat(getRepeatableFlag('var', inputs.var));
-  cmdParts = cmdParts.concat(getRepeatableFlag('var-file', inputs.varFile));
+    // Planning modes (mutually exclusive)
+    if (inputs.destroy === 'true') cmdParts.push('--destroy');
+    if (inputs.refreshOnly === 'true') cmdParts.push('--refresh-only');
 
-  // Other options
-  if (inputs.compactWarnings === 'true') cmdParts.push('--compact-warnings');
-  if (inputs.detailedExitcode === 'true') cmdParts.push('--detailed-exitcode');
-  if (inputs.generateConfigOut) cmdParts.push(getFlag('generate-config-out', inputs.generateConfigOut, 'string'));
-  if (inputs.input === 'false') cmdParts.push('--input=false');
-  if (inputs.json === 'true') cmdParts.push('--json');
-  if (inputs.lock === 'false') cmdParts.push('--lock=false');
-  if (inputs.lockTimeout && inputs.lockTimeout !== '0s') cmdParts.push(getFlag('lock-timeout', inputs.lockTimeout, 'string'));
-  if (inputs.noColor === 'true') cmdParts.push('--no-color');
-  if (inputs.concise === 'true') cmdParts.push('--concise');
-  if (inputs.out) cmdParts.push(getFlag('out', inputs.out, 'string'));
-  if (inputs.parallelism && inputs.parallelism !== '10') cmdParts.push(getFlag('parallelism', inputs.parallelism, 'string'));
-  if (inputs.state) cmdParts.push(getFlag('state', inputs.state, 'string'));
-  if (inputs.showSensitive === 'true') cmdParts.push('--show-sensitive');
+    // Planning options
+    if (inputs.refresh === 'false') cmdParts.push('--refresh=false');
+    cmdParts = cmdParts.concat(getRepeatableFlag('replace', inputs.replace));
+    cmdParts = cmdParts.concat(getRepeatableFlag('target', inputs.target));
+    if (inputs.targetFile) cmdParts.push(getFlag('target-file', inputs.targetFile, 'string'));
+    cmdParts = cmdParts.concat(getRepeatableFlag('exclude', inputs.exclude));
+    if (inputs.excludeFile) cmdParts.push(getFlag('exclude-file', inputs.excludeFile, 'string'));
+    cmdParts = cmdParts.concat(getRepeatableFlag('var', inputs.var));
+    cmdParts = cmdParts.concat(getRepeatableFlag('var-file', inputs.varFile));
+  }
 
   // Remove empty strings
   cmdParts = cmdParts.filter(Boolean);
@@ -81,6 +108,8 @@ async function run() {
     
     const inputs = {
       chdir: core.getInput('chdir'),
+      planFile: core.getInput('plan-file'),
+      autoApprove: core.getInput('auto-approve'),
       destroy: core.getInput('destroy'),
       refreshOnly: core.getInput('refresh-only'),
       refresh: core.getInput('refresh'),
@@ -91,10 +120,9 @@ async function run() {
       excludeFile: core.getInput('exclude-file'),
       var: core.getInput('var'),
       varFile: core.getInput('var-file'),
-      out: core.getInput('out'),
       compactWarnings: core.getInput('compact-warnings'),
-      detailedExitcode: core.getInput('detailed-exitcode'),
-      generateConfigOut: core.getInput('generate-config-out'),
+      consolidateWarnings: core.getInput('consolidate-warnings'),
+      consolidateErrors: core.getInput('consolidate-errors'),
       input: core.getInput('input'),
       json: core.getInput('json'),
       lock: core.getInput('lock'),
@@ -103,11 +131,14 @@ async function run() {
       concise: core.getInput('concise'),
       parallelism: core.getInput('parallelism'),
       state: core.getInput('state'),
+      stateOut: core.getInput('state-out'),
+      backup: core.getInput('backup'),
       showSensitive: core.getInput('show-sensitive'),
-      displayPlan: core.getInput('display-plan')
+      deprecation: core.getInput('deprecation'),
+      displayOutput: core.getInput('display-output')
     };
 
-    const cmd = buildTofuPlanCommand(inputs);
+    const cmd = buildTofuApplyCommand(inputs);
     core.info(`Running: ${cmd}`);
     
     let output;
@@ -119,30 +150,25 @@ async function run() {
       output = error.stdout || error.message;
       exitCode = error.status || 1;
       
-      // If detailed-exitcode is enabled, exit codes 0, 1, and 2 are expected
-      if (inputs.detailedExitcode === 'true' && (exitCode === 0 || exitCode === 2)) {
-        core.info(`tofu plan completed with exit code ${exitCode}.`);
-      } else if (exitCode !== 0) {
-        // Still show the output even if there's an error
-        if (output && inputs.displayPlan !== 'false') {
-          core.startGroup('📋 OpenTofu Plan Output (with errors)');
-          console.log(output);
-          core.endGroup();
-        }
-        throw error;
+      // Always show the output even if there's an error
+      if (output && inputs.displayOutput !== 'false') {
+        core.startGroup('� OpenTofu Apply Output (with errors)');
+        console.log(output);
+        core.endGroup();
       }
+      throw error;
     }
     
-    // Print the plan output to the console for visibility
-    if (output && inputs.displayPlan !== 'false') {
-      core.startGroup('📋 OpenTofu Plan Output');
+    // Print the apply output to the console for visibility
+    if (output && inputs.displayOutput !== 'false') {
+      core.startGroup('✅ OpenTofu Apply Output');
       console.log(output);
       core.endGroup();
     }
     
-    core.setOutput('plan-output', output);
+    core.setOutput('apply-output', output);
     core.setOutput('exitcode', exitCode);
-    core.info('tofu plan completed successfully.');
+    core.info('tofu apply completed successfully.');
   } catch (error) {
     core.setFailed(error.message);
   }
@@ -152,7 +178,7 @@ async function run() {
 module.exports = {
   getFlag,
   getRepeatableFlag,
-  buildTofuPlanCommand,
+  buildTofuApplyCommand,
   run
 };
 

--- a/index.js
+++ b/index.js
@@ -26,42 +26,69 @@ function getRepeatableFlag(name, value) {
   return value.split(',').map(v => `--${name}=${v.trim()}`);
 }
 
-function buildTofuPlanCommand(inputs) {
-  let cmdParts = ['tofu', 'plan'];
+function buildTofuApplyCommand(inputs) {
+  let cmdParts = ['tofu', 'apply'];
 
   // Global option
   if (inputs.chdir) {
-    cmdParts = ['tofu', `-chdir=${inputs.chdir}`, 'plan'];
+    cmdParts = ['tofu', `-chdir=${inputs.chdir}`, 'apply'];
   }
 
-  // Planning modes (mutually exclusive)
-  if (inputs.destroy === 'true') cmdParts.push('--destroy');
-  if (inputs.refreshOnly === 'true') cmdParts.push('--refresh-only');
+  // If plan file is provided, use saved plan mode
+  if (inputs.planFile) {
+    cmdParts.push(inputs.planFile);
+    // In saved plan mode, only certain options are allowed
+    if (inputs.autoApprove === 'true') cmdParts.push('--auto-approve');
+    if (inputs.compactWarnings === 'true') cmdParts.push('--compact-warnings');
+    if (inputs.consolidateWarnings === 'true') cmdParts.push('--consolidate-warnings');
+    if (inputs.consolidateErrors === 'true') cmdParts.push('--consolidate-errors');
+    if (inputs.input === 'false') cmdParts.push('--input=false');
+    if (inputs.json === 'true') cmdParts.push('--json');
+    if (inputs.lock === 'false') cmdParts.push('--lock=false');
+    if (inputs.lockTimeout && inputs.lockTimeout !== '0s') cmdParts.push(getFlag('lock-timeout', inputs.lockTimeout, 'string'));
+    if (inputs.noColor === 'true') cmdParts.push('--no-color');
+    if (inputs.concise === 'true') cmdParts.push('--concise');
+    if (inputs.parallelism && inputs.parallelism !== '10') cmdParts.push(getFlag('parallelism', inputs.parallelism, 'string'));
+    if (inputs.state) cmdParts.push(getFlag('state', inputs.state, 'string'));
+    if (inputs.stateOut) cmdParts.push(getFlag('state-out', inputs.stateOut, 'string'));
+    if (inputs.backup) cmdParts.push(getFlag('backup', inputs.backup, 'string'));
+    if (inputs.showSensitive === 'true') cmdParts.push('--show-sensitive');
+    if (inputs.deprecation && inputs.deprecation !== 'module:all') cmdParts.push(getFlag('deprecation', inputs.deprecation, 'string'));
+  } else {
+    // Automatic plan mode - planning options are available
+    
+    // Apply-specific options
+    if (inputs.autoApprove === 'true') cmdParts.push('--auto-approve');
+    if (inputs.compactWarnings === 'true') cmdParts.push('--compact-warnings');
+    if (inputs.consolidateWarnings === 'true') cmdParts.push('--consolidate-warnings');
+    if (inputs.consolidateErrors === 'true') cmdParts.push('--consolidate-errors');
+    if (inputs.input === 'false') cmdParts.push('--input=false');
+    if (inputs.json === 'true') cmdParts.push('--json');
+    if (inputs.lock === 'false') cmdParts.push('--lock=false');
+    if (inputs.lockTimeout && inputs.lockTimeout !== '0s') cmdParts.push(getFlag('lock-timeout', inputs.lockTimeout, 'string'));
+    if (inputs.noColor === 'true') cmdParts.push('--no-color');
+    if (inputs.concise === 'true') cmdParts.push('--concise');
+    if (inputs.parallelism && inputs.parallelism !== '10') cmdParts.push(getFlag('parallelism', inputs.parallelism, 'string'));
+    if (inputs.state) cmdParts.push(getFlag('state', inputs.state, 'string'));
+    if (inputs.stateOut) cmdParts.push(getFlag('state-out', inputs.stateOut, 'string'));
+    if (inputs.backup) cmdParts.push(getFlag('backup', inputs.backup, 'string'));
+    if (inputs.showSensitive === 'true') cmdParts.push('--show-sensitive');
+    if (inputs.deprecation && inputs.deprecation !== 'module:all') cmdParts.push(getFlag('deprecation', inputs.deprecation, 'string'));
 
-  // Planning options
-  if (inputs.refresh === 'false') cmdParts.push('--refresh=false');
-  cmdParts = cmdParts.concat(getRepeatableFlag('replace', inputs.replace));
-  cmdParts = cmdParts.concat(getRepeatableFlag('target', inputs.target));
-  if (inputs.targetFile) cmdParts.push(getFlag('target-file', inputs.targetFile, 'string'));
-  cmdParts = cmdParts.concat(getRepeatableFlag('exclude', inputs.exclude));
-  if (inputs.excludeFile) cmdParts.push(getFlag('exclude-file', inputs.excludeFile, 'string'));
-  cmdParts = cmdParts.concat(getRepeatableFlag('var', inputs.var));
-  cmdParts = cmdParts.concat(getRepeatableFlag('var-file', inputs.varFile));
+    // Planning modes (mutually exclusive)
+    if (inputs.destroy === 'true') cmdParts.push('--destroy');
+    if (inputs.refreshOnly === 'true') cmdParts.push('--refresh-only');
 
-  // Other options
-  if (inputs.compactWarnings === 'true') cmdParts.push('--compact-warnings');
-  if (inputs.detailedExitcode === 'true') cmdParts.push('--detailed-exitcode');
-  if (inputs.generateConfigOut) cmdParts.push(getFlag('generate-config-out', inputs.generateConfigOut, 'string'));
-  if (inputs.input === 'false') cmdParts.push('--input=false');
-  if (inputs.json === 'true') cmdParts.push('--json');
-  if (inputs.lock === 'false') cmdParts.push('--lock=false');
-  if (inputs.lockTimeout && inputs.lockTimeout !== '0s') cmdParts.push(getFlag('lock-timeout', inputs.lockTimeout, 'string'));
-  if (inputs.noColor === 'true') cmdParts.push('--no-color');
-  if (inputs.concise === 'true') cmdParts.push('--concise');
-  if (inputs.out) cmdParts.push(getFlag('out', inputs.out, 'string'));
-  if (inputs.parallelism && inputs.parallelism !== '10') cmdParts.push(getFlag('parallelism', inputs.parallelism, 'string'));
-  if (inputs.state) cmdParts.push(getFlag('state', inputs.state, 'string'));
-  if (inputs.showSensitive === 'true') cmdParts.push('--show-sensitive');
+    // Planning options
+    if (inputs.refresh === 'false') cmdParts.push('--refresh=false');
+    cmdParts = cmdParts.concat(getRepeatableFlag('replace', inputs.replace));
+    cmdParts = cmdParts.concat(getRepeatableFlag('target', inputs.target));
+    if (inputs.targetFile) cmdParts.push(getFlag('target-file', inputs.targetFile, 'string'));
+    cmdParts = cmdParts.concat(getRepeatableFlag('exclude', inputs.exclude));
+    if (inputs.excludeFile) cmdParts.push(getFlag('exclude-file', inputs.excludeFile, 'string'));
+    cmdParts = cmdParts.concat(getRepeatableFlag('var', inputs.var));
+    cmdParts = cmdParts.concat(getRepeatableFlag('var-file', inputs.varFile));
+  }
 
   // Remove empty strings
   cmdParts = cmdParts.filter(Boolean);
@@ -75,6 +102,8 @@ async function run() {
     
     const inputs = {
       chdir: core.getInput('chdir'),
+      planFile: core.getInput('plan-file'),
+      autoApprove: core.getInput('auto-approve'),
       destroy: core.getInput('destroy'),
       refreshOnly: core.getInput('refresh-only'),
       refresh: core.getInput('refresh'),
@@ -85,10 +114,9 @@ async function run() {
       excludeFile: core.getInput('exclude-file'),
       var: core.getInput('var'),
       varFile: core.getInput('var-file'),
-      out: core.getInput('out'),
       compactWarnings: core.getInput('compact-warnings'),
-      detailedExitcode: core.getInput('detailed-exitcode'),
-      generateConfigOut: core.getInput('generate-config-out'),
+      consolidateWarnings: core.getInput('consolidate-warnings'),
+      consolidateErrors: core.getInput('consolidate-errors'),
       input: core.getInput('input'),
       json: core.getInput('json'),
       lock: core.getInput('lock'),
@@ -97,11 +125,14 @@ async function run() {
       concise: core.getInput('concise'),
       parallelism: core.getInput('parallelism'),
       state: core.getInput('state'),
+      stateOut: core.getInput('state-out'),
+      backup: core.getInput('backup'),
       showSensitive: core.getInput('show-sensitive'),
-      displayPlan: core.getInput('display-plan')
+      deprecation: core.getInput('deprecation'),
+      displayOutput: core.getInput('display-output')
     };
 
-    const cmd = buildTofuPlanCommand(inputs);
+    const cmd = buildTofuApplyCommand(inputs);
     core.info(`Running: ${cmd}`);
     
     let output;
@@ -113,30 +144,25 @@ async function run() {
       output = error.stdout || error.message;
       exitCode = error.status || 1;
       
-      // If detailed-exitcode is enabled, exit codes 0, 1, and 2 are expected
-      if (inputs.detailedExitcode === 'true' && (exitCode === 0 || exitCode === 2)) {
-        core.info(`tofu plan completed with exit code ${exitCode}.`);
-      } else if (exitCode !== 0) {
-        // Still show the output even if there's an error
-        if (output && inputs.displayPlan !== 'false') {
-          core.startGroup('📋 OpenTofu Plan Output (with errors)');
-          console.log(output);
-          core.endGroup();
-        }
-        throw error;
+      // Always show the output even if there's an error
+      if (output && inputs.displayOutput !== 'false') {
+        core.startGroup('� OpenTofu Apply Output (with errors)');
+        console.log(output);
+        core.endGroup();
       }
+      throw error;
     }
     
-    // Print the plan output to the console for visibility
-    if (output && inputs.displayPlan !== 'false') {
-      core.startGroup('📋 OpenTofu Plan Output');
+    // Print the apply output to the console for visibility
+    if (output && inputs.displayOutput !== 'false') {
+      core.startGroup('✅ OpenTofu Apply Output');
       console.log(output);
       core.endGroup();
     }
     
-    core.setOutput('plan-output', output);
+    core.setOutput('apply-output', output);
     core.setOutput('exitcode', exitCode);
-    core.info('tofu plan completed successfully.');
+    core.info('tofu apply completed successfully.');
   } catch (error) {
     core.setFailed(error.message);
   }
@@ -146,7 +172,7 @@ async function run() {
 module.exports = {
   getFlag,
   getRepeatableFlag,
-  buildTofuPlanCommand,
+  buildTofuApplyCommand,
   run
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "github-tofu-plan",
+  "name": "github-tofu-apply",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "github-tofu-plan",
+      "name": "github-tofu-apply",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
@@ -1038,9 +1038,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "24.3.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
-      "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
+      "version": "24.3.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.1.tgz",
+      "integrity": "sha512-3vXmQDXy+woz+gnrTvuvNrPzekOi+Ds0ReMxw0LzBiK3a+1k0kQn9f2NWk+lgD4rJehFUmYy2gMhJ2ZI+7YP9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1365,9 +1365,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001737",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001737.tgz",
-      "integrity": "sha512-BiloLiXtQNrY5UyF0+1nSJLXUENuhka2pzy2Fx5pGxqavdrxSCW4U6Pn/PoG3Efspi2frRbHpBV2XsrPE6EDlw==",
+      "version": "1.0.30001741",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001741.tgz",
+      "integrity": "sha512-QGUGitqsc8ARjLdgAfxETDhRbJ0REsP6O3I96TAth/mVjh2cYzN2u+3AzPP3aVSm2FehEItaJw1xd+IGBXWeSw==",
       "dev": true,
       "funding": [
         {
@@ -1558,9 +1558,9 @@
       }
     },
     "node_modules/dedent": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.6.0.tgz",
-      "integrity": "sha512-F1Z+5UCFpmQUzJa11agbyPVMbpgT/qA3/SKyJ1jyBgm7dUcUEa8v9JwDkerSQXfakBwFljIxhOJqGkjUwZ9FSA==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.0.tgz",
+      "integrity": "sha512-HGFtf8yhuhGhqO07SV79tRp+br4MnbdjeVxotpn1QBl30pcLLCQjX5b2295ll0fv8RKDKsmWYrl05usHM9CewQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -1603,9 +1603,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.211",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.211.tgz",
-      "integrity": "sha512-IGBvimJkotaLzFnwIVgW9/UD/AOJ2tByUmeOrtqBfACSbAw5b1G0XpvdaieKyc7ULmbwXVx+4e4Be8pOPBrYkw==",
+      "version": "1.5.214",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.214.tgz",
+      "integrity": "sha512-TpvUNdha+X3ybfU78NoQatKvQEm1oq3lf2QbnmCEdw+Bd9RuIAY+hJTvq1avzHM0f7EJfnH3vbCnbzKzisc/9Q==",
       "dev": true,
       "license": "ISC"
     },

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "github-tofu-plan",
-  "version": "1.1.0",
+  "name": "github-tofu-apply",
+  "version": "1.0.0",
   "main": "index.js",
   "license": "MIT",
-  "description": "A GitHub Action to run tofu plan with all supported options",
+  "description": "A GitHub Action to run tofu apply with all supported options",
   "scripts": {
     "test": "jest",
     "test:integration": "jest --testPathPattern=integration",


### PR DESCRIPTION
This is a major refactor that transforms the GitHub Action from running 'tofu plan' to 'tofu apply' with comprehensive apply functionality.

## Major Changes

### Core Functionality
- Changed main command from 'tofu plan' to 'tofu apply'
- Implemented dual operation modes:
  - Automatic Plan Mode: Creates and applies plan in one step
  - Saved Plan Mode: Applies pre-created plan files
- Added auto-approval support for CI/CD workflows

### Action Configuration (action.yml)
- Updated action name from 'Tofu Plan' to 'Tofu Apply'
- Added apply-specific inputs:
  - plan-file: Support for saved plan files
  - auto-approve: Skip interactive confirmation
  - consolidate-warnings/consolidate-errors: Error grouping
  - state-out, backup: Legacy backend options
  - deprecation: Warning control
- Removed plan-specific inputs:
  - out: Plan output file (not applicable for apply)
  - detailed-exitcode: Plan-specific exit codes
  - generate-config-out: Plan-specific config generation
- Updated outputs: plan-output → apply-output
- Updated branding: eye/blue → check-circle/green

### Code Implementation (index.js)
- Renamed buildTofuPlanCommand → buildTofuApplyCommand
- Implemented smart option handling based on operation mode
- Added proper input validation for apply-specific options
- Updated error handling for apply operations
- Enhanced output display with apply-specific messaging

### Test Suite
- Updated all tests to use buildTofuApplyCommand
- Added comprehensive test coverage for both operation modes
- Added tests for auto-approval and saved plan functionality
- Maintained 100% test coverage (59 passing tests)

### Documentation (README.md)
- Complete rewrite for tofu apply usage
- Added examples for both operation modes
- Documented auto-approval and CI/CD workflows
- Added two-step workflow examples (plan → apply)
- Clear documentation of option availability per mode

### Package Management
- Updated package name: github-tofu-plan → github-tofu-apply
- Reset version to 1.0.0 for new action
- Rebuilt distribution with ncc build

## Breaking Changes
- Action name changed from 'tofu-plan' to 'tofu-apply'
- Output name changed from 'plan-output' to 'apply-output'
- Removed plan-specific input options
- Function exports renamed in module interface

## Features
- ✅ Auto-approval for CI/CD pipelines
- ✅ Saved plan file support
- ✅ Error consolidation options
- ✅ Legacy backend compatibility
- ✅ Comprehensive option validation
- ✅ Smart mode detection (automatic vs saved plan)

Closes: Refactor from plan to apply functionality

