### PR TITLE
fix: restrict OpenTofu options for saved plan file mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ jobs:
 | working-directory   | The directory in which to run tofu apply.                                    | `.`         |
 | chdir               | Switch working directory before executing tofu apply (--chdir).               | `''`        |
 | plan-file           | Path to a saved plan file to apply. If provided, skips planning phase.      | `''`        |
-| auto-approve        | Skip interactive approval of plan before applying (--auto-approve).         | `false`     |
+| auto-approve        | Skip interactive approval of plan before applying (--auto-approve). Only available when not using a saved plan file. | `false`     |
 | destroy             | Create a destroy plan (--destroy). Only available when not using a saved plan file. | `false`     |
 | refresh-only        | Create a refresh-only plan (--refresh-only). Only available when not using a saved plan file. | `false`     |
 | refresh             | Skip the default behavior of syncing state before applying (--refresh=false). Only available when not using a saved plan file. | `true`      |
@@ -81,8 +81,8 @@ jobs:
 | compact-warnings    | Show warning messages in compact form (--compact-warnings).                 | `false`     |
 | consolidate-warnings| Consolidate similar warning messages (--consolidate-warnings).              | `false`     |
 | consolidate-errors  | Consolidate similar error messages (--consolidate-errors).                  | `false`     |
-| input               | Ask for input if necessary (--input=true|false).                            | `false`     |
-| json                | Produce output in JSON format (--json). Requires --auto-approve or saved plan file. | `false`     |
+| input               | Ask for input if necessary (--input=true|false). Only available when not using a saved plan file. | `false`     |
+| json                | Produce output in JSON format (--json). Only available when not using a saved plan file. | `false`     |
 | lock                | Enable or disable state locking (--lock=true|false).                        | `true`      |
 | lock-timeout        | Override the time to wait for a state lock (--lock-timeout=DURATION).       | `0s`        |
 | no-color            | Disable color codes in output (--no-color).                                 | `false`     |

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -92,12 +92,12 @@ describe('buildTofuApplyCommand', () => {
     expect(buildTofuApplyCommand(inputs)).toBe('tofu apply saved-plan');
   });
 
-  test('should handle saved plan file with auto-approve', () => {
+  test('should handle saved plan file (auto-approve ignored)', () => {
     const inputs = {
       planFile: 'saved-plan',
-      autoApprove: 'true'
+      autoApprove: 'true'  // This should be ignored in saved plan mode
     };
-    expect(buildTofuApplyCommand(inputs)).toBe('tofu apply saved-plan --auto-approve');
+    expect(buildTofuApplyCommand(inputs)).toBe('tofu apply saved-plan');
   });
 
   test('should add auto-approve in automatic plan mode', () => {
@@ -256,15 +256,16 @@ describe('buildTofuApplyCommand', () => {
   test('should handle saved plan file mode with limited options', () => {
     const inputs = {
       planFile: 'saved-plan',
-      autoApprove: 'true',
-      noColor: 'true',
-      json: 'true',
+      autoApprove: 'true',  // Should be ignored
+      noColor: 'true',      // Should be included
+      json: 'true',         // Should be ignored
+      input: 'false',       // Should be ignored
       // These should be ignored in saved plan mode
       destroy: 'true',
       var: 'env=prod',
       target: 'aws_instance.web'
     };
-    expect(buildTofuApplyCommand(inputs)).toBe('tofu apply saved-plan --auto-approve --json --no-color');
+    expect(buildTofuApplyCommand(inputs)).toBe('tofu apply saved-plan --no-color');
   });
 
   test('should handle refresh-only mode', () => {

--- a/__tests__/integration.test.js
+++ b/__tests__/integration.test.js
@@ -151,11 +151,11 @@ describe('OpenTofu Apply Integration Tests', () => {
     test('should generate command for apply with saved plan in CI', () => {
       const inputs = {
         planFile: 'ci-plan',
-        input: 'false',
-        noColor: 'true',
-        json: 'true'
+        input: 'false',    // Should be ignored (not allowed with saved plans)
+        noColor: 'true',   // Should be included
+        json: 'true'       // Should be ignored (not allowed with saved plans)
       };
-      expect(buildTofuApplyCommand(inputs)).toBe('tofu apply ci-plan --input=false --json --no-color');
+      expect(buildTofuApplyCommand(inputs)).toBe('tofu apply ci-plan --no-color');
     });
   });
 
@@ -189,11 +189,12 @@ describe('OpenTofu Apply Integration Tests', () => {
         destroy: 'true',
         var: 'ignored=true',
         target: 'aws_instance.ignored',
+        autoApprove: 'true',  // Should be ignored (not allowed with saved plans)
+        input: 'false',       // Should be ignored (not allowed with saved plans)
         // These should be included
-        autoApprove: 'true',
         noColor: 'true'
       };
-      expect(buildTofuApplyCommand(inputs)).toBe('tofu apply saved-plan --auto-approve --no-color');
+      expect(buildTofuApplyCommand(inputs)).toBe('tofu apply saved-plan --no-color');
     });
   });
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -43,21 +43,16 @@ function buildTofuApplyCommand(inputs) {
   // If plan file is provided, use saved plan mode
   if (inputs.planFile) {
     cmdParts.push(inputs.planFile);
-    // In saved plan mode, only certain options are allowed
-    if (inputs.autoApprove === 'true') cmdParts.push('--auto-approve');
+    // In saved plan mode, only very limited options are allowed according to OpenTofu docs
+    // The plan file contains all the planning decisions, so most options are ignored
     if (inputs.compactWarnings === 'true') cmdParts.push('--compact-warnings');
     if (inputs.consolidateWarnings === 'true') cmdParts.push('--consolidate-warnings');
     if (inputs.consolidateErrors === 'true') cmdParts.push('--consolidate-errors');
-    if (inputs.input === 'false') cmdParts.push('--input=false');
-    if (inputs.json === 'true') cmdParts.push('--json');
     if (inputs.lock === 'false') cmdParts.push('--lock=false');
     if (inputs.lockTimeout && inputs.lockTimeout !== '0s') cmdParts.push(getFlag('lock-timeout', inputs.lockTimeout, 'string'));
     if (inputs.noColor === 'true') cmdParts.push('--no-color');
     if (inputs.concise === 'true') cmdParts.push('--concise');
     if (inputs.parallelism && inputs.parallelism !== '10') cmdParts.push(getFlag('parallelism', inputs.parallelism, 'string'));
-    if (inputs.state) cmdParts.push(getFlag('state', inputs.state, 'string'));
-    if (inputs.stateOut) cmdParts.push(getFlag('state-out', inputs.stateOut, 'string'));
-    if (inputs.backup) cmdParts.push(getFlag('backup', inputs.backup, 'string'));
     if (inputs.showSensitive === 'true') cmdParts.push('--show-sensitive');
     if (inputs.deprecation && inputs.deprecation !== 'module:all') cmdParts.push(getFlag('deprecation', inputs.deprecation, 'string'));
   } else {

--- a/index.js
+++ b/index.js
@@ -37,21 +37,16 @@ function buildTofuApplyCommand(inputs) {
   // If plan file is provided, use saved plan mode
   if (inputs.planFile) {
     cmdParts.push(inputs.planFile);
-    // In saved plan mode, only certain options are allowed
-    if (inputs.autoApprove === 'true') cmdParts.push('--auto-approve');
+    // In saved plan mode, only very limited options are allowed according to OpenTofu docs
+    // The plan file contains all the planning decisions, so most options are ignored
     if (inputs.compactWarnings === 'true') cmdParts.push('--compact-warnings');
     if (inputs.consolidateWarnings === 'true') cmdParts.push('--consolidate-warnings');
     if (inputs.consolidateErrors === 'true') cmdParts.push('--consolidate-errors');
-    if (inputs.input === 'false') cmdParts.push('--input=false');
-    if (inputs.json === 'true') cmdParts.push('--json');
     if (inputs.lock === 'false') cmdParts.push('--lock=false');
     if (inputs.lockTimeout && inputs.lockTimeout !== '0s') cmdParts.push(getFlag('lock-timeout', inputs.lockTimeout, 'string'));
     if (inputs.noColor === 'true') cmdParts.push('--no-color');
     if (inputs.concise === 'true') cmdParts.push('--concise');
     if (inputs.parallelism && inputs.parallelism !== '10') cmdParts.push(getFlag('parallelism', inputs.parallelism, 'string'));
-    if (inputs.state) cmdParts.push(getFlag('state', inputs.state, 'string'));
-    if (inputs.stateOut) cmdParts.push(getFlag('state-out', inputs.stateOut, 'string'));
-    if (inputs.backup) cmdParts.push(getFlag('backup', inputs.backup, 'string'));
     if (inputs.showSensitive === 'true') cmdParts.push('--show-sensitive');
     if (inputs.deprecation && inputs.deprecation !== 'module:all') cmdParts.push(getFlag('deprecation', inputs.deprecation, 'string'));
   } else {


### PR DESCRIPTION
- Remove incompatible options (--auto-approve, --input, --json, --state, --state-out, --backup) when applying saved plan files
- Saved plan files contain all planning decisions and most options are ignored/incompatible per OpenTofu docs
- Update tests to reflect correct behavior for both automatic and saved plan modes
- Update documentation to clarify option availability per mode
- Fixes 'Error: Too many command line arguments' when using saved plan files

